### PR TITLE
[feat] Add JWT strategy, guards, decorators, and update controllers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.7",
+        "@types/passport-jwt": "^4.0.1",
         "@types/pg": "^8.15.5",
         "@types/supertest": "^6.0.2",
         "eslint": "^9.18.0",
@@ -4004,6 +4005,35 @@
       "integrity": "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/passport": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
+      "integrity": "sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/passport-jwt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/passport-jwt/-/passport-jwt-4.0.1.tgz",
+      "integrity": "sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/jsonwebtoken": "*",
+        "@types/passport-strategy": "*"
+      }
+    },
+    "node_modules/@types/passport-strategy": {
+      "version": "0.2.38",
+      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
+      "integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*"
       }
     },
     "node_modules/@types/pg": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.7",
+    "@types/passport-jwt": "^4.0.1",
     "@types/pg": "^8.15.5",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.18.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,9 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from './core/auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
+import { APP_GUARD } from '@nestjs/core';
+import { RolesGuard } from './common/guards/roles.guard';
+import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
 
 @Module({
   imports: [
@@ -8,6 +11,10 @@ import { ConfigModule } from '@nestjs/config';
       isGlobal: true,
     }),
     AuthModule,
+  ],
+  providers: [
+    { provide: APP_GUARD, useClass: JwtAuthGuard },
+    { provide: APP_GUARD, useClass: RolesGuard },
   ],
 })
 export class AppModule {}

--- a/src/common/decorators/public.decorator.ts
+++ b/src/common/decorators/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/src/common/decorators/roles.decorator.ts
+++ b/src/common/decorators/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { UserRole } from '../enums/user-role';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/common/guards/jwt-auth.guard.ts
+++ b/src/common/guards/jwt-auth.guard.ts
@@ -1,0 +1,19 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AuthGuard } from '@nestjs/passport';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private reflector: Reflector) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext) {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    return isPublic ? true : super.canActivate(context);
+  }
+}

--- a/src/common/guards/roles.guard.ts
+++ b/src/common/guards/roles.guard.ts
@@ -1,0 +1,30 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { UserRole } from '../enums/user-role';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+import { User } from '../types/user.type';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (!requiredRoles) return true;
+
+    const { user } = context.switchToHttp().getRequest<{ user: User }>();
+
+    if (!user || !requiredRoles.includes(user.role)) {
+      throw new ForbiddenException('You do not have access to this endpoint');
+    }
+    return true;
+  }
+}

--- a/src/common/types/jwt.type.ts
+++ b/src/common/types/jwt.type.ts
@@ -1,0 +1,9 @@
+import { UserRole } from '../enums/user-role';
+
+export type JwtPayload = {
+  sub: string;
+  email: string;
+  role: UserRole;
+  iat: number;
+  exp: number;
+};

--- a/src/common/types/user.type.ts
+++ b/src/common/types/user.type.ts
@@ -1,0 +1,9 @@
+import { UserRole } from '../enums/user-role';
+
+export type User = {
+  id: string;
+  email: string;
+  password: string;
+  role: UserRole;
+  createdAt: Date;
+};

--- a/src/core/auth/auth.controller.ts
+++ b/src/core/auth/auth.controller.ts
@@ -12,12 +12,14 @@ import {
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { LoginDto, RegisterDto } from './auth.dto';
+import { Public } from '@/common/decorators/public.decorator';
 
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
+  @Public()
   @Post('register')
   @ApiOperation({ summary: 'Register a new user' })
   @ApiBody({
@@ -33,6 +35,7 @@ export class AuthController {
     return this.authService.register(registerDto);
   }
 
+  @Public()
   @Post('login')
   @HttpCode(200)
   @ApiOperation({ summary: 'User login' })

--- a/src/core/auth/auth.module.ts
+++ b/src/core/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { UsersModule } from '@/resources/users/users.module';
 import { DatabaseModule } from '../database/database.module';
+import { JwtStrategy } from './jwt.strategy';
 
 @Module({
   imports: [
@@ -13,12 +14,16 @@ import { DatabaseModule } from '../database/database.module';
     JwtModule.registerAsync({
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => ({
-        secret: configService.get<string>('JWT_SECRET'),
-        signOptions: { expiresIn: configService.get<string>('JWT_EXPIRES_IN') },
+        secret: configService.get<string>('JWT_SECRET', { infer: true }),
+        signOptions: {
+          expiresIn: configService.get<string>('JWT_EXPIRES_IN', {
+            infer: true,
+          }),
+        },
       }),
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService],
+  providers: [AuthService, JwtStrategy],
 })
 export class AuthModule {}

--- a/src/core/auth/jwt.strategy.ts
+++ b/src/core/auth/jwt.strategy.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+import { JwtPayload } from '@/common/types/jwt.type';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(private readonly configService: ConfigService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: configService.getOrThrow<string>('JWT_SECRET'),
+    });
+  }
+
+  validate(payload: JwtPayload) {
+    return { userId: payload.sub, email: payload.email, role: payload.role };
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,20 @@
-import { NestFactory } from '@nestjs/core';
+import { NestFactory, Reflector } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { swagger } from './app.swagger';
 import { ValidationPipe } from '@nestjs/common';
+import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
+import { RolesGuard } from './common/guards/roles.guard';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
   app.useGlobalPipes(new ValidationPipe());
+
   swagger(app);
+
+  const reflector = app.get(Reflector);
+  app.useGlobalGuards(new JwtAuthGuard(reflector), new RolesGuard(reflector));
+
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap().catch((error) => {

--- a/src/resources/users/user.controller.ts
+++ b/src/resources/users/user.controller.ts
@@ -1,4 +1,5 @@
 import {
+  ApiBearerAuth,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiParam,
@@ -6,6 +7,8 @@ import {
 } from '@nestjs/swagger';
 import { UsersService } from './users.service';
 import { Controller, Get, NotFoundException, Param } from '@nestjs/common';
+import { Roles } from '@/common/decorators/roles.decorator';
+import { UserRole } from '@/common/enums/user-role';
 
 @ApiTags('users')
 @Controller('users')
@@ -13,6 +16,8 @@ export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Get(':email')
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
   @ApiParam({
     name: 'email',
     type: String,


### PR DESCRIPTION
Add JWT strategy, guards, decorators, and update controllers
- add JWT authentication and route protection
- create `@Public()` for public routes and `@Roles()` for role-based access
- implement `JwtAuthGuard` and `RolesGuard`
- update controllers to use guards and decorators
- update Swagger docs for auth changes