### PR TITLE
[feat] Implement sports classes endpoints and user/admin actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ npm run start:dev
 ```
 
 ## Migrations
-**Generate a Migration**
+**Generate a migration**
 
 When you make changes to the database schema:
 
@@ -61,7 +61,7 @@ When you make changes to the database schema:
 npm run db:generate
 ```
 
-**Drop Migrations Safely**
+**Drop migrations safely**
 
 If a migration needs to be removed, never delete it manually.
 Instead, run:
@@ -70,12 +70,20 @@ Instead, run:
 npm run db:migrate-drop
 ```
 
-**Apply Migrations**
+**Apply migrations**
 
 To update your local database schema:
 
 ```bash
 npm run db:migrate-run
+```
+
+**Run seed script**
+
+Run the seed script to add initial data to the database::
+
+```bash
+npm run seed
 ```
 
 ## Run tests

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,8 +27,12 @@ export default tseslint.config(
   {
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
-      '@typescript-eslint/no-floating-promises': 'warn',
-      '@typescript-eslint/no-unsafe-argument': 'warn',
+      '@typescript-eslint/no-floating-promises': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/unbound-method': 'off',
     },
   },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@types/bcrypt": "^6.0.0",
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.14",
-        "@types/node": "^22.10.7",
+        "@types/node": "^22.17.2",
         "@types/passport-jwt": "^4.0.1",
         "@types/pg": "^8.15.5",
         "@types/supertest": "^6.0.2",
@@ -55,7 +55,7 @@
         "ts-loader": "^9.5.2",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.7.3",
+        "typescript": "^5.9.2",
         "typescript-eslint": "^8.20.0"
       }
     },
@@ -4000,9 +4000,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.17.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.0.tgz",
-      "integrity": "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==",
+      "version": "22.17.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
+      "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
       "dependencies": {
         "undici-types": "~6.21.0"
       }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate-run": "drizzle-kit migrate",
     "db:migrate-drop": "drizzle-kit drop",
+    "seed": "ts-node -r tsconfig-paths/register src/core/database/seed.ts",
     "test": "jest --config ./test/jest.config.ts",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
@@ -53,7 +54,7 @@
     "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",
-    "@types/node": "^22.10.7",
+    "@types/node": "^22.17.2",
     "@types/passport-jwt": "^4.0.1",
     "@types/pg": "^8.15.5",
     "@types/supertest": "^6.0.2",
@@ -69,7 +70,7 @@
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.7.3",
+    "typescript": "^5.9.2",
     "typescript-eslint": "^8.20.0"
   },
   "jest": {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
 import { RolesGuard } from './common/guards/roles.guard';
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
+import { ClassesModule } from './resources/classes/classes.module';
 
 @Module({
   imports: [
@@ -11,6 +12,7 @@ import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
       isGlobal: true,
     }),
     AuthModule,
+    ClassesModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: JwtAuthGuard },

--- a/src/common/constants/weekdays.ts
+++ b/src/common/constants/weekdays.ts
@@ -1,0 +1,11 @@
+export const WEEKDAYS = [
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+  'Sunday',
+] as const;
+
+export type Weekday = (typeof WEEKDAYS)[number];

--- a/src/common/enums/user-role.ts
+++ b/src/common/enums/user-role.ts
@@ -1,5 +1,4 @@
 export enum UserRole {
   USER = 'user',
-  EMPLOYEE = 'employee',
   ADMIN = 'admin',
 }

--- a/src/common/types/auth-user.type.ts
+++ b/src/common/types/auth-user.type.ts
@@ -1,0 +1,9 @@
+export interface AuthenticatedUser {
+  id: string;
+  email: string;
+  role: string;
+}
+
+export type AuthenticatedRequest = Request & {
+  user: AuthenticatedUser;
+};

--- a/src/common/types/classes.type.ts
+++ b/src/common/types/classes.type.ts
@@ -1,0 +1,15 @@
+export type Class = {
+  id: string;
+  sportId: string;
+  description: string;
+  startTime: string;
+  classDays: string[];
+  createdAt: Date;
+};
+
+export type ClassApplication = {
+  id: string;
+  classId: string;
+  userId: string;
+  appliedAt: Date;
+};

--- a/src/common/types/jwt.type.ts
+++ b/src/common/types/jwt.type.ts
@@ -7,3 +7,7 @@ export type JwtPayload = {
   iat: number;
   exp: number;
 };
+
+export type LoginResponse = {
+  access_token: string;
+};

--- a/src/core/auth/jwt.strategy.ts
+++ b/src/core/auth/jwt.strategy.ts
@@ -15,6 +15,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   validate(payload: JwtPayload) {
-    return { userId: payload.sub, email: payload.email, role: payload.role };
+    return { id: payload.sub, email: payload.email, role: payload.role };
   }
 }

--- a/src/core/database/migrations/0001_rare_sauron.sql
+++ b/src/core/database/migrations/0001_rare_sauron.sql
@@ -1,0 +1,12 @@
+CREATE EXTENSION IF NOT EXISTS citext;--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "role" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "role" SET DEFAULT 'user'::text;--> statement-breakpoint
+DROP TYPE "public"."role";--> statement-breakpoint
+CREATE TYPE "public"."role" AS ENUM('user', 'admin');--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "role" SET DEFAULT 'user'::"public"."role";--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "role" SET DATA TYPE "public"."role" USING "role"::"public"."role";--> statement-breakpoint
+ALTER TABLE "sports" ALTER COLUMN "name" SET DATA TYPE citext;--> statement-breakpoint
+ALTER TABLE "classes" ADD COLUMN "start_at" time NOT NULL;--> statement-breakpoint
+ALTER TABLE "classes" ADD COLUMN "end_at" time NOT NULL;--> statement-breakpoint
+ALTER TABLE "classes" DROP COLUMN "duration";--> statement-breakpoint
+ALTER TABLE "sports" ADD CONSTRAINT "sports_name_unique" UNIQUE("name");

--- a/src/core/database/migrations/meta/0001_snapshot.json
+++ b/src/core/database/migrations/meta/0001_snapshot.json
@@ -1,0 +1,290 @@
+{
+  "id": "21a04d2a-c39a-4951-bd87-c8eb56a8dcb1",
+  "prevId": "253f1c87-5a8b-4c95-8762-b977859c153d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.class_schedules": {
+      "name": "class_schedules",
+      "schema": "",
+      "columns": {
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "class_schedules_class_id_classes_id_fk": {
+          "name": "class_schedules_class_id_classes_id_fk",
+          "tableFrom": "class_schedules",
+          "tableTo": "classes",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "class_schedules_user_id_users_id_fk": {
+          "name": "class_schedules_user_id_users_id_fk",
+          "tableFrom": "class_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classes": {
+      "name": "classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sport_id": {
+          "name": "sport_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_days": {
+          "name": "class_days",
+          "type": "weekday[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "classes_sport_id_sports_id_fk": {
+          "name": "classes_sport_id_sports_id_fk",
+          "tableFrom": "classes",
+          "tableTo": "sports",
+          "columnsFrom": [
+            "sport_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "classes_id_unique": {
+          "name": "classes_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sports": {
+      "name": "sports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sports_id_unique": {
+          "name": "sports_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "sports_name_unique": {
+          "name": "sports_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_id_unique": {
+          "name": "users_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.weekday": {
+      "name": "weekday",
+      "schema": "public",
+      "values": [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/core/database/migrations/meta/_journal.json
+++ b/src/core/database/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1754648818845,
       "tag": "0000_freezing_forge",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1755463110404,
+      "tag": "0001_rare_sauron",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/database/schema.ts
+++ b/src/core/database/schema.ts
@@ -1,16 +1,16 @@
 import { relations, sql } from 'drizzle-orm';
 import {
-  integer,
   pgEnum,
   pgTable,
+  time,
   timestamp,
   uuid,
   varchar,
 } from 'drizzle-orm/pg-core';
 
-export const role = pgEnum('role', ['user', 'employee', 'admin']);
+export const role = pgEnum('role', ['user', 'admin']);
 
-export const weekdayEnum = pgEnum('weekday', [
+export const weekday = pgEnum('weekday', [
   'Monday',
   'Tuesday',
   'Wednesday',
@@ -44,7 +44,7 @@ export const sports = pgTable('sports', {
     .default(sql`gen_random_uuid()`)
     .unique()
     .primaryKey(),
-  name: varchar('name', { length: 256 }).notNull(),
+  name: varchar('name').notNull().unique(),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 });
 
@@ -67,8 +67,9 @@ export const classes = pgTable('classes', {
     })
     .notNull(),
   description: varchar('description', { length: 256 }),
-  duration: integer('duration').notNull(),
-  classDays: weekdayEnum('class_days').array().notNull(),
+  classDays: weekday('class_days').array().notNull(),
+  startAt: time('start_at').notNull(),
+  endAt: time('end_at').notNull(),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 });
 

--- a/src/core/database/seed.ts
+++ b/src/core/database/seed.ts
@@ -1,0 +1,23 @@
+import 'dotenv/config';
+import { Pool } from 'pg';
+import { seedSportsAndClasses } from './seed/sports-and-classes.seed';
+import { drizzle } from 'drizzle-orm/node-postgres';
+
+async function main() {
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  const db = drizzle(pool);
+
+  try {
+    await seedSportsAndClasses(db);
+    console.log('Seeding complete');
+  } catch (err) {
+    console.error('Seeding failed', err);
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('Unhandled error in seed script:', err);
+  process.exit(1);
+});

--- a/src/core/database/seed/sports-and-classes.seed.ts
+++ b/src/core/database/seed/sports-and-classes.seed.ts
@@ -1,0 +1,59 @@
+import { randomUUID } from 'crypto';
+import { classes, sports } from '../schema';
+import { drizzle } from 'drizzle-orm/node-postgres';
+
+export async function seedSportsAndClasses(db: ReturnType<typeof drizzle>) {
+  const initialSports = ['Baseball', 'Basketball', 'Football'];
+
+  const insertedSports = await db
+    .insert(sports)
+    .values(initialSports.map((name) => ({ name })))
+    .onConflictDoNothing()
+    .returning({ id: sports.id, name: sports.name });
+
+  const sportMap = Object.fromEntries(
+    insertedSports.map((s) => [s.name, s.id]),
+  );
+
+  await db
+    .insert(classes)
+    .values([
+      {
+        id: randomUUID(),
+        sportId: sportMap['Baseball'],
+        description: 'Beginner baseball fundamentals for kids',
+        classDays: ['Monday', 'Wednesday', 'Friday'],
+        startAt: '17:00',
+        endAt: '18:30',
+        createdAt: new Date(),
+      },
+      {
+        id: randomUUID(),
+        sportId: sportMap['Basketball'],
+        description: 'Intermediate basketball skills and drills',
+        classDays: ['Tuesday', 'Thursday', 'Saturday'],
+        startAt: '18:00',
+        endAt: '20:00',
+        createdAt: new Date(),
+      },
+      {
+        id: randomUUID(),
+        sportId: sportMap['Football'],
+        description: 'Advanced football tactics and conditioning',
+        classDays: ['Monday', 'Thursday', 'Sunday'],
+        startAt: '19:30',
+        endAt: '22:00',
+        createdAt: new Date(),
+      },
+      {
+        id: randomUUID(),
+        sportId: sportMap['Football'],
+        description: 'Intermediate football tactics and conditioning',
+        classDays: ['Tuesday', 'Thursday', 'Friday'],
+        startAt: '17:00',
+        endAt: '18:30',
+        createdAt: new Date(),
+      },
+    ])
+    .onConflictDoNothing();
+}

--- a/src/core/database/seed/sports-and-classes.seed.ts
+++ b/src/core/database/seed/sports-and-classes.seed.ts
@@ -1,19 +1,31 @@
 import { randomUUID } from 'crypto';
-import { classes, sports } from '../schema';
+import { classes, sports, users } from '../schema';
 import { drizzle } from 'drizzle-orm/node-postgres';
+import * as bcrypt from 'bcrypt';
 
 export async function seedSportsAndClasses(db: ReturnType<typeof drizzle>) {
+  const hashedPassword = await bcrypt.hash('password123', 10);
+  await db
+    .insert(users)
+    .values([
+      {
+        id: randomUUID(),
+        email: 'test@example.com',
+        password: hashedPassword,
+      },
+    ])
+    .onConflictDoNothing();
+
   const initialSports = ['Baseball', 'Basketball', 'Football'];
 
-  const insertedSports = await db
+  await db
     .insert(sports)
     .values(initialSports.map((name) => ({ name })))
-    .onConflictDoNothing()
-    .returning({ id: sports.id, name: sports.name });
+    .onConflictDoNothing();
 
-  const sportMap = Object.fromEntries(
-    insertedSports.map((s) => [s.name, s.id]),
-  );
+  const allSports = await db.select().from(sports);
+
+  const sportMap = Object.fromEntries(allSports.map((s) => [s.name, s.id]));
 
   await db
     .insert(classes)

--- a/src/resources/classes/classes.controller.ts
+++ b/src/resources/classes/classes.controller.ts
@@ -22,6 +22,7 @@ import { ClassesService } from './classes.service';
 import {
   ClassIdDto,
   CreateClassDto,
+  FilterApplicationsDto,
   FilterClassesDto,
   UpdateClassDto,
 } from './classes.dto';
@@ -63,9 +64,26 @@ export class ClassesController {
   @ApiBadRequestResponse({
     description: 'Schedule conflict or invalid request',
   })
-  async apply(@Param('id') classId: string, @Req() req: AuthenticatedRequest) {
+  async apply(@Param() param: ClassIdDto, @Req() req: AuthenticatedRequest) {
     const userId = req.user.id;
+    const classId = param.id;
     return this.classesService.applyForClass(userId, classId);
+  }
+
+  @Get('/:id/applicants')
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Get users who applied for a class in a given period',
+    description:
+      'Only users with the ADMIN role can see all users who applied for a class',
+  })
+  @ApiOkResponse({ description: 'List of applicants' })
+  async getApplicants(
+    @Param() param: ClassIdDto,
+    @Query() filters: FilterApplicationsDto,
+  ) {
+    return this.classesService.getApplicants(param.id, filters);
   }
 
   @Post()
@@ -91,8 +109,8 @@ export class ClassesController {
   @ApiOkResponse({ description: 'Class updated' })
   @ApiForbiddenResponse({ description: 'Forbidden: Admins only' })
   @ApiNotFoundResponse({ description: 'Class not found' })
-  async update(@Param('id') id: string, @Body() dto: UpdateClassDto) {
-    return this.classesService.update(id, dto);
+  async update(@Param() param: ClassIdDto, @Body() dto: UpdateClassDto) {
+    return this.classesService.update(param.id, dto);
   }
 
   @Delete('/:id')
@@ -107,7 +125,7 @@ export class ClassesController {
   })
   @ApiForbiddenResponse({ description: 'Forbidden: Admins only' })
   @ApiNotFoundResponse({ description: 'Class not found' })
-  async delete(@Param('id') id: string) {
-    return this.classesService.delete(id);
+  async delete(@Param() param: ClassIdDto) {
+    return this.classesService.delete(param.id);
   }
 }

--- a/src/resources/classes/classes.controller.ts
+++ b/src/resources/classes/classes.controller.ts
@@ -1,0 +1,113 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+} from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { ClassesService } from './classes.service';
+import {
+  ClassIdDto,
+  CreateClassDto,
+  FilterClassesDto,
+  UpdateClassDto,
+} from './classes.dto';
+import { AuthenticatedRequest } from '@/common/types/auth-user.type';
+import { Roles } from '@/common/decorators/roles.decorator';
+import { UserRole } from '@/common/enums/user-role';
+
+@ApiTags('classes')
+@ApiBearerAuth()
+@Controller('classes')
+export class ClassesController {
+  constructor(private readonly classesService: ClassesService) {}
+
+  @Get()
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Get all sports classes (optional filter by sports)',
+  })
+  @ApiOkResponse({ description: 'List of classes' })
+  async getAll(@Query() filter: FilterClassesDto) {
+    const sports = filter.sports?.split(',').map((s) => s.trim());
+    return this.classesService.getAll({ sports });
+  }
+
+  @Get('/:id')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get a sport class by ID' })
+  @ApiOkResponse({ description: 'Sport class' })
+  @ApiNotFoundResponse({ description: 'Sport class not found' })
+  async getById(@Param() param: ClassIdDto) {
+    return this.classesService.getById(param.id);
+  }
+
+  @Post('/:id/apply')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Apply for a sport class' })
+  @ApiOkResponse({ description: 'Application successful' })
+  @ApiNotFoundResponse({ description: 'Sport class not found' })
+  @ApiBadRequestResponse({
+    description: 'Schedule conflict or invalid request',
+  })
+  async apply(@Param('id') classId: string, @Req() req: AuthenticatedRequest) {
+    const userId = req.user.id;
+    return this.classesService.applyForClass(userId, classId);
+  }
+
+  @Post()
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Create a new sport class',
+    description: 'Only users with the ADMIN role can create a class',
+  })
+  @ApiOkResponse({ description: 'Class created' })
+  @ApiForbiddenResponse({ description: 'Forbidden: Admins only' })
+  async create(@Body() dto: CreateClassDto) {
+    return this.classesService.create(dto);
+  }
+
+  @Patch('/:id')
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Update a sport class',
+    description: 'Only users with the ADMIN role can update a class',
+  })
+  @ApiOkResponse({ description: 'Class updated' })
+  @ApiForbiddenResponse({ description: 'Forbidden: Admins only' })
+  @ApiNotFoundResponse({ description: 'Class not found' })
+  async update(@Param('id') id: string, @Body() dto: UpdateClassDto) {
+    return this.classesService.update(id, dto);
+  }
+
+  @Delete('/:id')
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Delete a sport class',
+    description: 'Only users with the ADMIN role can delete a class',
+  })
+  @ApiOkResponse({
+    description: 'Class deleted',
+  })
+  @ApiForbiddenResponse({ description: 'Forbidden: Admins only' })
+  @ApiNotFoundResponse({ description: 'Class not found' })
+  async delete(@Param('id') id: string) {
+    return this.classesService.delete(id);
+  }
+}

--- a/src/resources/classes/classes.dto.ts
+++ b/src/resources/classes/classes.dto.ts
@@ -3,8 +3,6 @@ import { ApiProperty, ApiPropertyOptional, PartialType } from '@nestjs/swagger';
 import {
   ArrayNotEmpty,
   IsArray,
-  IsDate,
-  IsDateString,
   IsEnum,
   IsNotEmpty,
   IsOptional,

--- a/src/resources/classes/classes.dto.ts
+++ b/src/resources/classes/classes.dto.ts
@@ -3,6 +3,8 @@ import { ApiProperty, ApiPropertyOptional, PartialType } from '@nestjs/swagger';
 import {
   ArrayNotEmpty,
   IsArray,
+  IsDate,
+  IsDateString,
   IsEnum,
   IsNotEmpty,
   IsOptional,
@@ -25,6 +27,28 @@ export class ClassIdDto {
   })
   @IsUUID('4')
   id: string;
+}
+
+export class FilterApplicationsDto {
+  @ApiPropertyOptional({
+    description: 'Start date (inclusive) to filter applications',
+    example: '2025-08-01',
+  })
+  @IsOptional()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, {
+    message: 'from must be in YYYY-MM-DD format',
+  })
+  from?: string;
+
+  @ApiPropertyOptional({
+    description: 'End date (inclusive) to filter applications',
+    example: '2025-08-31',
+  })
+  @IsOptional()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, {
+    message: 'to must be in YYYY-MM-DD format',
+  })
+  to?: string;
 }
 
 export class CreateClassDto {

--- a/src/resources/classes/classes.dto.ts
+++ b/src/resources/classes/classes.dto.ts
@@ -1,0 +1,71 @@
+import { Weekday, WEEKDAYS } from '@/common/constants/weekdays';
+import { ApiProperty, ApiPropertyOptional, PartialType } from '@nestjs/swagger';
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Matches,
+} from 'class-validator';
+
+export class FilterClassesDto {
+  @ApiPropertyOptional({ example: 'Basketball,Football' })
+  @IsOptional()
+  @IsString()
+  sports?: string;
+}
+
+export class ClassIdDto {
+  @ApiProperty({
+    description: 'Class ID',
+    example: 'd290f1ee-6c54-4b01-90e6-d701748f0851',
+  })
+  @IsUUID('4')
+  id: string;
+}
+
+export class CreateClassDto {
+  @ApiProperty({
+    description: 'ID of the sport this class belongs to',
+    example: 'd290f1ee-6c54-4b01-90e6-d701748f0851',
+  })
+  @IsUUID('4')
+  sportId: string;
+
+  @ApiProperty({
+    description: 'Description of the class',
+    example: 'Beginner basketball fundamentals for kids',
+  })
+  @IsString()
+  @IsNotEmpty()
+  description: string;
+
+  @ApiProperty({
+    description: 'Days of the week when the class is held',
+    example: ['Monday', 'Wednesday', 'Friday'],
+    isArray: true,
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsEnum(WEEKDAYS, { each: true })
+  classDays: Weekday[];
+
+  @ApiProperty({
+    description: 'Start time of the class (HH:MM format)',
+    example: '17:00',
+  })
+  @Matches(/^([0-1]\d|2[0-3]):([0-5]\d)$/)
+  startAt: string;
+
+  @ApiProperty({
+    description: 'End time of the class (HH:MM format)',
+    example: '18:30',
+  })
+  @Matches(/^([0-1]\d|2[0-3]):([0-5]\d)$/)
+  endAt: string;
+}
+
+export class UpdateClassDto extends PartialType(CreateClassDto) {}

--- a/src/resources/classes/classes.module.ts
+++ b/src/resources/classes/classes.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ClassesController } from './classes.controller';
+import { ClassesService } from './classes.service';
+
+@Module({
+  controllers: [ClassesController],
+  providers: [ClassesService],
+})
+export class ClassesModule {}

--- a/src/resources/classes/classes.service.ts
+++ b/src/resources/classes/classes.service.ts
@@ -154,6 +154,10 @@ export class ClassesService {
       .where(eq(classes.id, id))
       .returning();
 
+    if (!updatedClass) {
+      throw new NotFoundException(`Class with id ${id} not found`);
+    }
+
     return updatedClass;
   }
 

--- a/src/resources/classes/classes.service.ts
+++ b/src/resources/classes/classes.service.ts
@@ -1,11 +1,11 @@
 import { DatabaseService } from '@/core/database/database.service';
-import { classes, classSchedules, sports } from '@/core/database/schema';
+import { classes, classSchedules, sports, users } from '@/core/database/schema';
 import {
   BadRequestException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { eq, and, inArray, SQL } from 'drizzle-orm';
+import { eq, and, inArray, SQL, gte, lte, sql } from 'drizzle-orm';
 import { CreateClassDto, UpdateClassDto } from './classes.dto';
 
 @Injectable()
@@ -97,6 +97,32 @@ export class ClassesService {
         endAt: sportClass.endAt,
       },
     };
+  }
+
+  async getApplicants(
+    classId: string,
+    filters?: { from?: string; to?: string },
+  ) {
+    const conditions: Array<SQL | undefined> = [
+      eq(classSchedules.classId, classId),
+      filters?.from
+        ? gte(sql`DATE(${classSchedules.createdAt})`, new Date(filters.from))
+        : undefined,
+      filters?.to
+        ? lte(sql`DATE(${classSchedules.createdAt})`, new Date(filters.to))
+        : undefined,
+    ].filter(Boolean);
+
+    return this.databaseService.db
+      .select({
+        classId: classSchedules.classId,
+        userId: users.id,
+        userEmail: users.email,
+        appliedDate: sql`DATE(${classSchedules.createdAt})`.as('appliedDate'),
+      })
+      .from(classSchedules)
+      .leftJoin(users, eq(users.id, classSchedules.userId))
+      .where(and(...conditions));
   }
 
   async create(dto: CreateClassDto) {

--- a/src/resources/classes/classes.service.ts
+++ b/src/resources/classes/classes.service.ts
@@ -1,0 +1,146 @@
+import { DatabaseService } from '@/core/database/database.service';
+import { classes, classSchedules, sports } from '@/core/database/schema';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { eq, and, inArray, SQL } from 'drizzle-orm';
+import { CreateClassDto, UpdateClassDto } from './classes.dto';
+
+@Injectable()
+export class ClassesService {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async getAll(filters?: { sports?: string[] }) {
+    const conditions: Array<SQL | undefined> = [];
+
+    if (filters?.sports?.length) {
+      conditions.push(inArray(sports.name, filters.sports));
+    }
+    return this.databaseService.db
+      .select({
+        id: classes.id,
+        sport: sports.name,
+        description: classes.description,
+        classDays: classes.classDays,
+        startAt: classes.startAt,
+        endAt: classes.endAt,
+      })
+      .from(classes)
+      .leftJoin(sports, eq(classes.sportId, sports.id))
+      .where(conditions.length ? and(...conditions) : undefined);
+  }
+
+  async getById(classId: string) {
+    const [result] = await this.databaseService.db
+      .select({
+        id: classes.id,
+        sport: sports.name,
+        description: classes.description,
+        classDays: classes.classDays,
+        startAt: classes.startAt,
+        endAt: classes.endAt,
+      })
+      .from(classes)
+      .leftJoin(sports, eq(classes.sportId, sports.id))
+      .where(eq(classes.id, classId));
+
+    if (!result) {
+      throw new NotFoundException(`Class with id ${classId} not found`);
+    }
+
+    return result;
+  }
+
+  async applyForClass(userId: string, classId: string) {
+    const sportClass = await this.getById(classId);
+
+    const userApplications = await this.databaseService.db
+      .select({
+        classId: classSchedules.classId,
+        classDays: classes.classDays,
+        startAt: classes.startAt,
+        endAt: classes.endAt,
+      })
+      .from(classSchedules)
+      .leftJoin(classes, eq(classSchedules.classId, classes.id))
+      .where(eq(classSchedules.userId, userId));
+
+    const conflict = userApplications.some(
+      (application) =>
+        application.classDays?.some((day) =>
+          sportClass.classDays.includes(day),
+        ) &&
+        sportClass.startAt < application.endAt! &&
+        sportClass.endAt > application.startAt!,
+    );
+
+    if (conflict) {
+      throw new BadRequestException(
+        'You already have a class at this time and day',
+      );
+    }
+
+    await this.databaseService.db.insert(classSchedules).values({
+      userId,
+      classId,
+    });
+
+    return {
+      message: 'Application successful',
+      class: {
+        sport: sportClass.sport,
+        description: sportClass.description,
+        classDays: sportClass.classDays,
+        startAt: sportClass.startAt,
+        endAt: sportClass.endAt,
+      },
+    };
+  }
+
+  async create(dto: CreateClassDto) {
+    const [newClass] = await this.databaseService.db
+      .insert(classes)
+      .values({
+        sportId: dto.sportId,
+        description: dto.description ?? null,
+        classDays: dto.classDays,
+        startAt: dto.startAt,
+        endAt: dto.endAt,
+      })
+      .returning();
+    return newClass;
+  }
+
+  async update(id: string, dto: UpdateClassDto) {
+    await this.getById(id);
+
+    const [updatedClass] = await this.databaseService.db
+      .update(classes)
+      .set({
+        sportId: dto.sportId,
+        description: dto.description ?? null,
+        classDays: dto.classDays,
+        startAt: dto.startAt,
+        endAt: dto.endAt,
+      })
+      .where(eq(classes.id, id))
+      .returning();
+
+    return updatedClass;
+  }
+
+  async delete(id: string) {
+    const [deleted] = await this.databaseService.db
+      .delete(classes)
+      .where(eq(classes.id, id))
+      .returning();
+
+    if (!deleted) {
+      throw new NotFoundException(`Class with id ${id} not found`);
+    }
+
+    return { message: 'Class deleted successfully', class: deleted };
+  }
+}

--- a/test/e2e/classes.e2e.spec.ts
+++ b/test/e2e/classes.e2e.spec.ts
@@ -1,0 +1,100 @@
+import { AppModule } from '@/app.module';
+import { LoginResponse } from '@/common/types/jwt.type';
+import { DatabaseService } from '@/core/database/database.service';
+import { classes, sports, users } from '@/core/database/schema';
+import { seedSportsAndClasses } from '@/core/database/seed/sports-and-classes.seed';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { randomUUID } from 'crypto';
+import * as request from 'supertest';
+
+describe('Classes', () => {
+  let app: INestApplication;
+  let databaseService: DatabaseService;
+  let jwtToken: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+
+    databaseService = app.get(DatabaseService);
+  });
+
+  beforeEach(async () => {
+    await seedSportsAndClasses(databaseService.db);
+
+    const loginRes = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'test@example.com', password: 'password123' })
+      .expect(200);
+    const body = loginRes.body as LoginResponse;
+    jwtToken = body.access_token;
+  });
+
+  afterEach(async () => {
+    await databaseService.db.delete(users);
+    await databaseService.db.delete(classes);
+    await databaseService.db.delete(sports);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /classes?sports=Basketball', () => {
+    it('should return filtered classes', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/classes?sports=basketball')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .expect(200);
+
+      expect(response.body).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            description: 'Intermediate basketball skills and drills',
+          }),
+        ]),
+      );
+    });
+  });
+
+  describe('GET /classes/:id', () => {
+    it('should return class details', async () => {
+      const all = await request(app.getHttpServer())
+        .get('/classes')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .expect(200);
+      const first = all.body[0];
+
+      const response = await request(app.getHttpServer())
+        .get(`/classes/${first.id}`)
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .expect(200);
+
+      expect(response.body).toMatchObject({
+        id: first.id,
+        description: expect.any(String),
+        classDays: expect.any(Array),
+      });
+    });
+
+    it('should return 404 if class not found', async () => {
+      const nonExistentId = randomUUID();
+      const response = await request(app.getHttpServer())
+        .get(`/classes/${nonExistentId}`)
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .expect(404);
+
+      expect(response.body).toMatchObject({
+        statusCode: 404,
+        message: `Class with id ${nonExistentId} not found`,
+        error: 'Not Found',
+      });
+    });
+  });
+});

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -2,7 +2,7 @@
   "moduleFileExtensions": ["js", "json", "ts"],
   "rootDir": "..",
   "testEnvironment": "node",
-  "testMatch": ["**/test/e2e/**/*.e2e-spec.ts"],
+  "testMatch": ["**/test/e2e/**/*.e2e.spec.ts"],
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },

--- a/test/unit/classes.service.spec.ts
+++ b/test/unit/classes.service.spec.ts
@@ -1,0 +1,75 @@
+import { UpdateClassDto } from '@/resources/classes/classes.dto';
+import { ClassesService } from '@/resources/classes/classes.service';
+import { NotFoundException } from '@nestjs/common';
+
+describe('class schedule update', () => {
+  let classesService: ClassesService;
+  let mockDb: any;
+
+  beforeEach(() => {
+    mockDb = {
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      returning: jest.fn(),
+    };
+
+    classesService = new ClassesService({ db: mockDb } as any);
+    classesService.getById = jest.fn();
+  });
+
+  it('should update class successfully', async () => {
+    const dto: UpdateClassDto = {
+      sportId: '1',
+      description: 'Updated description',
+      classDays: ['Monday', 'Wednesday', 'Saturday'],
+      startAt: '10:00',
+      endAt: '11:30',
+    };
+
+    const existingClass = {
+      id: '1',
+      sport: 'Basketball',
+      description: 'Old description',
+      classDays: ['Monday', 'Wednesday'],
+      startAt: '09:00',
+      endAt: '10:00',
+    };
+
+    const updatedClass = {
+      id: '1',
+      sport: 'Basketball',
+      description: 'Updated description',
+      classDays: ['Monday', 'Wednesday', 'Saturday'],
+      startAt: '10:00',
+      endAt: '11:30',
+    };
+
+    (classesService.getById as jest.Mock).mockResolvedValue(existingClass);
+
+    mockDb.returning.mockResolvedValue([updatedClass]);
+
+    const result = await classesService.update('1', dto);
+
+    expect(result).toEqual(updatedClass);
+  });
+
+  it('should throw NotFoundException if no class updated', async () => {
+    const dto: UpdateClassDto = { sportId: '1' } as any;
+
+    (classesService.getById as jest.Mock).mockResolvedValue({
+      id: '1',
+      sport: 'Basketball',
+      description: 'Old description',
+      classDays: ['Monday'],
+      startAt: '09:00',
+      endAt: '10:00',
+    });
+
+    mockDb.returning.mockResolvedValue([]);
+
+    await expect(classesService.update('1', dto)).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+});


### PR DESCRIPTION
 Implement sports classes endpoints and user/admin actions:
- users can filter and retrieve all sports classes via query params, e.g. /api/classes?sports=Basketball,Football
- users can view details of a specific class, including week schedule, duration, and description
- users can apply for a sports class
- admins can manage sports classes (CRUD operations)
- admins can view users who applied for each course in a given period
- add tests