### PR TITLE
[fix] Hide password hash on user creation

### DIFF
--- a/src/resources/users/users.service.ts
+++ b/src/resources/users/users.service.ts
@@ -9,7 +9,16 @@ export class UsersService {
   constructor(private readonly databaseService: DatabaseService) {}
 
   async create(data: NewUserDto) {
-    return this.databaseService.db.insert(users).values(data).returning();
+    const user = await this.databaseService.db
+      .insert(users)
+      .values(data)
+      .returning({
+        id: users.id,
+        email: users.email,
+        role: users.role,
+        createdAt: users.createdAt,
+      });
+    return user;
   }
 
   async findByEmail(email: string) {


### PR DESCRIPTION
Hide password hash on user creation
- updated create user function to return only id, email, role, and createdAt
- prevents returning hashed passwords, fixing a potential security issue